### PR TITLE
Add LayerNorm layer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,5 @@ version = "0.1.0"
 authors = ["Daniël de Kok <me@danieldk.eu>"]
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
+tch = "0.1"

--- a/src/layers.rs
+++ b/src/layers.rs
@@ -1,0 +1,64 @@
+use tch::nn::Module;
+use tch::{self, Tensor};
+
+/// Layer that applies layer normalization.
+#[derive(Debug)]
+pub struct LayerNorm {
+    elementwise_affine: bool,
+    eps: f64,
+    normalized_shape: Vec<i64>,
+
+    weight: Option<Tensor>,
+    bias: Option<Tensor>,
+}
+
+impl LayerNorm {
+    /// Construct a layer normalization layer.
+    ///
+    /// The mean and standard deviation are computed over the last
+    /// number of dimensions with the shape defined by
+    /// `normalized_shape`. If `elementwise_affine` is `True`, a
+    /// learnable affine transformation of the shape
+    /// `normalized_shape` is added after normalization.
+    pub fn new(normalized_shape: impl Into<Vec<i64>>, eps: f64, elementwise_affine: bool) -> Self {
+        let normalized_shape = normalized_shape.into();
+
+        let (weight, bias) = if elementwise_affine {
+            (
+                Some(Tensor::ones(
+                    &normalized_shape,
+                    (tch::Kind::Float, tch::Device::Cpu),
+                )),
+                Some(Tensor::zeros(
+                    &normalized_shape,
+                    (tch::Kind::Float, tch::Device::Cpu),
+                )),
+            )
+        } else {
+            (None, None)
+        };
+
+        LayerNorm {
+            eps,
+            elementwise_affine,
+            normalized_shape,
+
+            weight,
+            bias,
+        }
+    }
+}
+
+impl Module for LayerNorm {
+    fn forward(&self, input: &Tensor) -> Tensor {
+        // XXX: last parameter is `cudnn_enable`. What happens if we always
+        //      set this to `true`?
+        input.layer_norm(
+            &self.normalized_shape,
+            self.weight.as_ref(),
+            self.bias.as_ref(),
+            self.eps,
+            false,
+        )
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,1 @@
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
-    }
-}
+pub mod layers;


### PR DESCRIPTION
This is based on the public API of the PyTorch `LayerNorm` layer.