### PR TITLE
Port BertLayer from Hugging Face transformers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ tch = "0.1"
 
 [dev-dependencies]
 approx = "0.3"
+maplit = "1"
 ndarray = { version = "0.13", features = ["approx"] }
 
 [features]

--- a/src/activations.rs
+++ b/src/activations.rs
@@ -1,0 +1,15 @@
+use tch::nn::Module;
+use tch::Tensor;
+
+pub trait Activation: Clone + Module {}
+
+#[derive(Clone, Copy, Debug)]
+pub struct GELU;
+
+impl Module for GELU {
+    fn forward(&self, input: &Tensor) -> Tensor {
+        input * 0.5 * (1.0 + (input / 2f64.sqrt()).erf())
+    }
+}
+
+impl Activation for GELU {}

--- a/src/hdf5_model.rs
+++ b/src/hdf5_model.rs
@@ -1,8 +1,9 @@
 use std::borrow::Borrow;
 
 use failure::Fallible;
-use hdf5::File;
+use hdf5::{Dataset, Group};
 use tch::nn::Path;
+use tch::Tensor;
 
 /// Trait to load models from a HDF5 of a Tensorflow checkpoint.
 pub trait LoadFromHDF5
@@ -15,6 +16,24 @@ where
     fn load_from_hdf5<'a>(
         vs: impl Borrow<Path<'a>>,
         config: &Self::Config,
-        file: File,
+        file: Group,
     ) -> Fallible<Self>;
+}
+
+pub fn load_affine(
+    group: Group,
+    weights: &str,
+    bias: &str,
+    input_features: i64,
+    output_features: i64,
+) -> Fallible<(Tensor, Tensor)> {
+    Ok((
+        load_tensor(group.dataset(weights)?, &[input_features, output_features])?,
+        load_tensor(group.dataset(bias)?, &[output_features])?,
+    ))
+}
+
+pub fn load_tensor(dataset: Dataset, shape: &[i64]) -> Fallible<Tensor> {
+    let tensor_raw: Vec<f32> = dataset.read_raw()?;
+    Ok(Tensor::of_slice(&tensor_raw).reshape(shape))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+pub mod activations;
+
 pub mod bert_model;
 
 pub(crate) mod cow;


### PR DESCRIPTION
This replaces PR #7. Compared to that PR, the `forward` parameters for model training (as opposed to finetuning) are removed. Moreover, all `new` constructors are removed, since they are only necessary for constructing new models.