### PR TITLE
Add support for attention masks in BertEncoder

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,3 +7,5 @@ pub(crate) mod cow;
 pub mod layers;
 
 pub mod hdf5_model;
+
+pub mod util;

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,45 @@
+use std::ops::Deref;
+
+use tch::{Kind, Tensor};
+
+/// Mask of logit values
+///
+/// This mask masks logits by setting inactive logits to a
+/// large negative value (`-10_000`).
+pub struct LogitsMask {
+    inner: Tensor,
+}
+
+impl LogitsMask {
+    /// Construct a logits mask from a boolean mask.
+    pub fn from_bool_mask(mask: &Tensor) -> Self {
+        assert_eq!(
+            mask.kind(),
+            Kind::Bool,
+            "Mask tensor does not have bool kind"
+        );
+
+        assert_eq!(
+            mask.size().len(),
+            2,
+            "Expected a mask of shape [batch_size, timesteps]"
+        );
+
+        // The attention mask has shape [batch_size, seq_len], extend
+        // to [batch_size, 1, 1, seq_len].
+        let extended_mask = mask.unsqueeze(1).unsqueeze(1);
+
+        // Use (very) negative values for time steps that should be masked.
+        let logits_mask = (1.0 - extended_mask.to_kind(Kind::Float)) * -10_000.;
+
+        LogitsMask { inner: logits_mask }
+    }
+}
+
+impl Deref for LogitsMask {
+    type Target = Tensor;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}


### PR DESCRIPTION
Normally, we want to mask attention for inactive timesteps, so that
their hidden states do not leak into the representations of active
time steps.

The API differs from Hugging Face transformers. In Hugging Face
transformers, the mask is converted to appropriate values that result
in near-zero probabilities in BertModel. This means that BertEncoder
already expects this special representation. However, since
BertEncoder (or even BertLayer) is the typical 'entry point' in
sticker-transformers, we perform the conversion in BertSelfAttention.