### PR TITLE
BertEmbeddings: initialize using BERT hyperparameters

### DIFF
--- a/src/bert_model.rs
+++ b/src/bert_model.rs
@@ -146,11 +146,17 @@ impl BertEmbeddings {
     pub fn new<'a>(vs: impl Borrow<Path<'a>>, config: &BertConfig) -> Self {
         let vs = vs.borrow();
 
+        let normal_init = Init::Randn {
+            mean: 0.,
+            stdev: config.initializer_range,
+        };
+
         let word_embeddings = Embedding::new(
             vs.sub("word_embeddings"),
             "embeddings",
             config.vocab_size,
             config.hidden_size,
+            normal_init,
         );
 
         let position_embeddings = Embedding::new(
@@ -158,6 +164,7 @@ impl BertEmbeddings {
             "embeddings",
             config.max_position_embeddings,
             config.hidden_size,
+            normal_init,
         );
 
         let token_type_embeddings = Embedding::new(
@@ -165,6 +172,7 @@ impl BertEmbeddings {
             "embeddings",
             config.type_vocab_size,
             config.hidden_size,
+            normal_init,
         );
 
         let layer_norm = LayerNorm::new(

--- a/src/layers.rs
+++ b/src/layers.rs
@@ -1,6 +1,6 @@
 use std::borrow::Borrow;
 
-use tch::nn::{self, Linear, Module, ModuleT, Path};
+use tch::nn::{Init, Linear, Module, ModuleT, Path};
 use tch::{self, Tensor};
 
 /// Trait to place layer tensors in the var store.
@@ -56,15 +56,12 @@ impl Embedding {
         name: &str,
         num_embeddings: i64,
         embedding_dim: i64,
+        init: Init,
     ) -> Self {
-        Embedding(vs.borrow().var(
-            name,
-            &[num_embeddings, embedding_dim],
-            nn::Init::Randn {
-                mean: 0.,
-                stdev: 1.,
-            },
-        ))
+        Embedding(
+            vs.borrow()
+                .var(name, &[num_embeddings, embedding_dim], init),
+        )
     }
 }
 


### PR DESCRIPTION
Initialize embeddings with the standard deviation specified by the
`initializer_range` BERT option.