### PR TITLE
Add a conversion script for a RoBERTa checkpoints to HDF5

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -20,6 +20,7 @@ in with nixpkgs; mkShell {
 
   propagatedBuildInputs = [
     (python3.withPackages (ps: with ps; [
+      danieldk.python3Packages.pytorch.v1_3_1
       h5py
       tensorflow-bin
     ]))

--- a/src/models/bert/mod.rs
+++ b/src/models/bert/mod.rs
@@ -303,8 +303,8 @@ impl LoadFromHDF5 for BertEmbeddings {
 
         let layer_norm_group = group.group("LayerNorm")?;
 
-        let weight = load_tensor(layer_norm_group.dataset("gamma")?, &[config.hidden_size])?;
-        let bias = load_tensor(layer_norm_group.dataset("beta")?, &[config.hidden_size])?;
+        let weight = load_tensor(layer_norm_group.dataset("weight")?, &[config.hidden_size])?;
+        let bias = load_tensor(layer_norm_group.dataset("bias")?, &[config.hidden_size])?;
 
         Ok(BertEmbeddings {
             word_embeddings: Embedding(word_embeddings)
@@ -440,7 +440,7 @@ impl LoadFromHDF5 for BertIntermediate {
     ) -> Fallible<Self> {
         let (dense_weight, dense_bias) = load_affine(
             group.group("dense")?,
-            "kernel",
+            "weight",
             "bias",
             config.hidden_size,
             config.intermediate_size,
@@ -600,7 +600,7 @@ impl LoadFromHDF5 for BertOutput {
 
         let (dense_weight, dense_bias) = load_affine(
             group.group("dense")?,
-            "kernel",
+            "weight",
             "bias",
             config.intermediate_size,
             config.hidden_size,
@@ -608,9 +608,9 @@ impl LoadFromHDF5 for BertOutput {
 
         let layer_norm_group = group.group("LayerNorm")?;
         let layer_norm_weight =
-            load_tensor(layer_norm_group.dataset("gamma")?, &[config.hidden_size])?;
+            load_tensor(layer_norm_group.dataset("weight")?, &[config.hidden_size])?;
         let layer_norm_bias =
-            load_tensor(layer_norm_group.dataset("beta")?, &[config.hidden_size])?;
+            load_tensor(layer_norm_group.dataset("bias")?, &[config.hidden_size])?;
 
         Ok(BertOutput {
             dense: Linear {
@@ -756,21 +756,21 @@ impl LoadFromHDF5 for BertSelfAttention {
 
         let (key_weight, key_bias) = load_affine(
             group.group("key")?,
-            "kernel",
+            "weight",
             "bias",
             config.hidden_size,
             all_head_size,
         )?;
         let (query_weight, query_bias) = load_affine(
             group.group("query")?,
-            "kernel",
+            "weight",
             "bias",
             config.hidden_size,
             all_head_size,
         )?;
         let (value_weight, value_bias) = load_affine(
             group.group("value")?,
-            "kernel",
+            "weight",
             "bias",
             config.hidden_size,
             all_head_size,
@@ -855,7 +855,7 @@ impl LoadFromHDF5 for BertSelfOutput {
 
         let (dense_weight, dense_bias) = load_affine(
             group.group("dense")?,
-            "kernel",
+            "weight",
             "bias",
             config.hidden_size,
             config.hidden_size,
@@ -863,9 +863,9 @@ impl LoadFromHDF5 for BertSelfOutput {
 
         let layer_norm_group = group.group("LayerNorm")?;
         let layer_norm_weight =
-            load_tensor(layer_norm_group.dataset("gamma")?, &[config.hidden_size])?;
+            load_tensor(layer_norm_group.dataset("weight")?, &[config.hidden_size])?;
         let layer_norm_bias =
-            load_tensor(layer_norm_group.dataset("beta")?, &[config.hidden_size])?;
+            load_tensor(layer_norm_group.dataset("bias")?, &[config.hidden_size])?;
 
         Ok(BertSelfOutput {
             dense: Linear {

--- a/utils/pytorch-roberta-to-hdf5.py
+++ b/utils/pytorch-roberta-to-hdf5.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+import re
+import sys
+
+import h5py
+import torch
+
+parser = argparse.ArgumentParser(
+    description='Convert a PyTorch RoBERTa checkpoint to HDF5.')
+parser.add_argument(
+    'model',
+    metavar='MODEL',
+    help='The model path')
+parser.add_argument('hdf5', metavar='HDF5', help='HDF5 output')
+
+if __name__ == "__main__":
+    args = parser.parse_args()
+
+    model = torch.load(args.model)
+
+    with h5py.File(args.hdf5, "w") as hdf5:
+        ignore = re.compile("adam_v|adam_m|global_step|lm_head|pooler")
+        kernel = re.compile("(key|query|value|dense)/weight")
+        for var, tensor in model.items():
+            # Skip unneeded layers
+            if ignore.search(var):
+                continue
+
+            var = var.replace("roberta", "bert")
+            var = var.replace("embeddings.weight", "embeddings")
+            var = var.replace("encoder.layer.", "encoder.layer_")
+            var = var.replace(".", "/")
+
+            # Attention weight matrices are transposed, compared to BERT.
+            if kernel.search(var):
+                tensor = tensor.t()
+
+            print("Adding %s..." % var, file=sys.stderr)
+
+            # Store the tensor in the HDF5 file.
+            hdf5.create_dataset(var, data=tensor)

--- a/utils/tf_checkpoint_to_hdf5.py
+++ b/utils/tf_checkpoint_to_hdf5.py
@@ -23,7 +23,7 @@ if __name__ == "__main__":
     model_vars = tf.train.list_variables(checkpoint_path)
 
     with h5py.File(args.hdf5, "w") as hdf5:
-        ignore = re.compile("adam_v|adam_m|global_step")
+        ignore = re.compile("adam_v|adam_m|global_step|cls|pooler")
         for var in model_vars:
             (var, shape) = var
 
@@ -31,9 +31,14 @@ if __name__ == "__main__":
             if ignore.search(var):
                 continue
 
-            print("Adding %s..." % var, file=sys.stderr)
+            # Rewrite some variable names
+            renamedVar = var.replace("kernel", "weight")
+            renamedVar = renamedVar.replace("gamma", "weight")
+            renamedVar = renamedVar.replace("beta", "bias")
+
+            print("Adding %s..." % renamedVar, file=sys.stderr)
 
             # Retrieve the tensor associated with the variable
             # and store it in the HDF5 file.
             tensor = tf.train.load_variable(checkpoint_path, var)
-            hdf5.create_dataset(var, data=tensor)
+            hdf5.create_dataset(renamedVar, data=tensor)


### PR DESCRIPTION
- Add a conversion script for converting a PyTorch RoBERTa checkpoint
  to HDF5.
- Adjust the BERT conversion script to produce HDF5 without the weird
  Tensorflow/BERT nomenclature: kernel/gamma/beta. Instead just use
  weight/weight/bias as RoBERTa does.
- Change the LoadFromHDF5 implementations to use the weight/bias
  naming.

This does not break compatibility with existing models, since we
already use weight/bias naming internally.