### PR TITLE
Add RobertaEmbeddings

### DIFF
--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -3,6 +3,9 @@
 pub mod bert;
 pub use bert::{BertConfig, BertEmbeddings, BertEncoder};
 
+pub mod roberta;
+pub use roberta::RobertaEmbeddings;
+
 pub mod sinusoidal;
 pub use sinusoidal::SinusoidalEmbeddings;
 

--- a/src/models/roberta/mod.rs
+++ b/src/models/roberta/mod.rs
@@ -1,0 +1,209 @@
+// Copyright 2018 The Google AI Language Team Authors and The HuggingFace Inc. team.
+// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+// Copyright (c) 2020 The sticker developers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::borrow::Borrow;
+
+use failure::Fallible;
+use hdf5::Group;
+use tch::nn::{ModuleT, Path};
+use tch::{Kind, Tensor};
+
+use crate::cow::CowTensor;
+use crate::hdf5_model::LoadFromHDF5;
+use crate::models::bert::{BertConfig, BertEmbeddings};
+
+const PADDING_IDX: i64 = 1;
+
+/// RoBERTa and XLM-RoBERTa embeddings.
+#[derive(Debug)]
+pub struct RobertaEmbeddings {
+    inner: BertEmbeddings,
+}
+
+impl RobertaEmbeddings {
+    /// Construct new RoBERTa embeddings with the given variable store
+    /// and Bert configuration.
+    pub fn new<'a>(vs: impl Borrow<Path<'a>>, config: &BertConfig) -> Self {
+        RobertaEmbeddings {
+            inner: BertEmbeddings::new(vs, config, false),
+        }
+    }
+
+    pub fn forward(
+        &self,
+        input_ids: &Tensor,
+        token_type_ids: Option<&Tensor>,
+        position_ids: Option<&Tensor>,
+        train: bool,
+    ) -> Tensor {
+        let position_ids = match position_ids {
+            Some(position_ids) => CowTensor::Borrowed(position_ids),
+            None => {
+                let mask = input_ids.ne(PADDING_IDX).to_kind(Kind::Int64);
+                let incremental_indices = mask.cumsum(1, Kind::Int64) * mask;
+                CowTensor::Owned(incremental_indices + PADDING_IDX)
+            }
+        };
+
+        self.inner.forward(
+            input_ids,
+            token_type_ids,
+            Some(position_ids.as_ref()),
+            train,
+        )
+    }
+}
+
+impl LoadFromHDF5 for RobertaEmbeddings {
+    type Config = BertConfig;
+
+    fn load_from_hdf5<'a>(
+        vs: impl Borrow<Path<'a>>,
+        config: &Self::Config,
+        file: Group,
+    ) -> Fallible<Self> {
+        BertEmbeddings::load_from_hdf5(vs, config, file)
+            .map(|embeds| RobertaEmbeddings { inner: embeds })
+    }
+}
+
+impl ModuleT for RobertaEmbeddings {
+    fn forward_t(&self, input: &Tensor, train: bool) -> Tensor {
+        self.forward(input, None, None, train)
+    }
+}
+
+#[cfg(feature = "model-tests")]
+#[cfg(test)]
+mod tests {
+    use std::convert::TryInto;
+
+    use approx::assert_abs_diff_eq;
+    use hdf5::File;
+    use ndarray::{array, ArrayD};
+    use tch::nn::{ModuleT, VarStore};
+    use tch::{Device, Kind, Tensor};
+
+    use crate::hdf5_model::LoadFromHDF5;
+    use crate::models::bert::{BertConfig, BertEncoder};
+    use crate::models::roberta::RobertaEmbeddings;
+
+    fn xlm_roberta_config() -> BertConfig {
+        BertConfig {
+            attention_probs_dropout_prob: 0.1,
+            hidden_act: "gelu".to_string(),
+            hidden_dropout_prob: 0.1,
+            hidden_size: 768,
+            initializer_range: 0.02,
+            intermediate_size: 3072,
+            layer_norm_eps: 1e-5,
+            max_position_embeddings: 514,
+            num_attention_heads: 12,
+            num_hidden_layers: 12,
+            type_vocab_size: 1,
+            vocab_size: 250002,
+        }
+    }
+
+    #[test]
+    fn xlm_roberta_embeddings() {
+        let config = xlm_roberta_config();
+        let roberta_file = File::open("testdata/xlm-roberta-base.hdf5", "r").unwrap();
+
+        let vs = VarStore::new(Device::Cpu);
+        let embeddings = RobertaEmbeddings::load_from_hdf5(
+            vs.root(),
+            &config,
+            roberta_file.group("bert/embeddings").unwrap(),
+        )
+        .unwrap();
+
+        // Subtokenization of: Veruntreute die AWO spendengeld ?
+        let pieces = Tensor::of_slice(&[
+            0i64, 310, 23451, 107, 6743, 68, 62, 43789, 207126, 49004, 705, 2,
+        ])
+        .reshape(&[1, 12]);
+
+        let summed_embeddings =
+            embeddings
+                .forward_t(&pieces, false)
+                .sum1(&[-1], false, Kind::Float);
+
+        let sums: ArrayD<f32> = (&summed_embeddings).try_into().unwrap();
+
+        // Verify output against Hugging Face transformers Python
+        // implementation.
+        assert_abs_diff_eq!(
+            sums,
+            (array![[
+                -9.1686, -4.2982, -0.7808, -0.7097, 0.0972, -3.0785, -3.6755, -2.1465, -2.9406,
+                -1.0627, -6.6043, -4.8064
+            ]])
+            .into_dyn(),
+            epsilon = 1e-4
+        );
+    }
+
+    #[test]
+    fn xlm_roberta_encoder() {
+        let config = xlm_roberta_config();
+        let roberta_file = File::open("testdata/xlm-roberta-base.hdf5", "r").unwrap();
+
+        let vs = VarStore::new(Device::Cpu);
+        let embeddings = RobertaEmbeddings::load_from_hdf5(
+            vs.root(),
+            &config,
+            roberta_file.group("bert/embeddings").unwrap(),
+        )
+        .unwrap();
+
+        let encoder = BertEncoder::load_from_hdf5(
+            vs.root(),
+            &config,
+            roberta_file.group("bert/encoder").unwrap(),
+        )
+        .unwrap();
+
+        // Subtokenization of: Veruntreute die AWO spendengeld ?
+        let pieces = Tensor::of_slice(&[
+            0i64, 310, 23451, 107, 6743, 68, 62, 43789, 207126, 49004, 705, 2,
+        ])
+        .reshape(&[1, 12]);
+
+        let embeddings = embeddings.forward_t(&pieces, false);
+
+        let all_hidden_states = encoder.forward_t(&embeddings, None, false);
+
+        let summed_last_hidden =
+            all_hidden_states
+                .last()
+                .unwrap()
+                .output
+                .sum1(&[-1], false, Kind::Float);
+
+        let sums: ArrayD<f32> = (&summed_last_hidden).try_into().unwrap();
+
+        assert_abs_diff_eq!(
+            sums,
+            (array![[
+                20.9693, 19.7502, 17.0594, 19.0700, 19.0065, 19.6254, 18.9379, 18.9275, 18.8922,
+                18.9505, 19.2682, 20.9411
+            ]])
+            .into_dyn(),
+            epsilon = 1e-4
+        );
+    }
+}

--- a/testdata/download-test-data.sh
+++ b/testdata/download-test-data.sh
@@ -1,14 +1,22 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 
-SCRIPTDIR="$(dirname "${BASH_SOURCE[0]}")"
-PARAMS="${SCRIPTDIR}/bert-base-german-cased.hdf5"
-
-if [ -e "${PARAMS}" ]; then
-  echo "The model was already downloaded."
-  exit 0
-fi
-
-curl -o "${PARAMS}" \
+models=(
   http://www.sfs.uni-tuebingen.de/a3-public-data/sticker2-models/bert-base-german-cased.hdf5
+  http://www.sfs.uni-tuebingen.de/a3-public-data/sticker2-models/xlm-roberta-base.hdf5
+)
+
+SCRIPTDIR="$(dirname "${BASH_SOURCE[0]}")"
+
+for model in ${models[@]}; do
+  model_file="${SCRIPTDIR}/$(basename $model)"
+
+  if [ -e "${model_file}" ]; then
+    echo "${model_file} is already available"
+    continue
+  fi
+
+  curl -o "${model_file}" "${model}"
+done
+


### PR DESCRIPTION
We cannot use BertEmbeddings directly, because RoBERTa embeddings
offset the position embeddings by the padding index. This change adds
the RobertaEmbeddings type. RobertaEmbeddings wraps BertEmbeddings,
constructing the correct position indices for the forward methods.

This change also adds unit tests that compares both RobertaEmbeddings
and RobertaEmbeddings + BertEncoder against the Hugging Face
Transformers output using the xlm-roberta-base model.