### PR TITLE
Add the `load-hdf5` feature for support for loading models from HDF5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 
 [dependencies]
 failure = "0.1"
-hdf5 = "0.5"
+hdf5 = { version = "0.5", optional = true }
 serde = { version = "1", features = ["derive"] }
 tch = "= 0.1.5"
 
@@ -28,4 +28,6 @@ maplit = "1"
 ndarray = { version = "0.13", features = ["approx"] }
 
 [features]
+default = ["load-hdf5"]
+load-hdf5 = ["hdf5"]
 model-tests = []

--- a/nix/Cargo.nix
+++ b/nix/Cargo.nix
@@ -2143,6 +2143,7 @@ rec {
           {
             name = "hdf5";
             packageId = "hdf5 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)";
+            optional = true;
           }
           {
             name = "serde";
@@ -2170,7 +2171,10 @@ rec {
           }
         ];
         features = {
+          "default" = [ "load-hdf5" ];
+          "load-hdf5" = [ "hdf5" ];
         };
+        resolvedDefaultFeatures = [ "default" "hdf5" "load-hdf5" ];
       };
     "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)"
       = rec {

--- a/src/layers.rs
+++ b/src/layers.rs
@@ -111,6 +111,7 @@ pub struct LayerNorm {
 }
 
 impl LayerNorm {
+    #[cfg(feature = "load-hdf5")]
     pub(crate) fn new_with_affine(
         normalized_shape: impl Into<Vec<i64>>,
         eps: f64,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod layers;
 
 pub mod models;
 
+#[cfg(feature = "load-hdf5")]
 pub mod hdf5_model;
 
 pub mod scalar_weighting;

--- a/tests.nix
+++ b/tests.nix
@@ -24,7 +24,16 @@ let
     defaultCrateOverrides = crateOverrides;
   };
   cargo_nix = pkgs.callPackage ./nix/Cargo.nix { inherit buildRustCrate; };
-in cargo_nix.rootCrate.build.override {
-  features = [ "model-tests" ];
-  runTests = true;
-}
+in [
+  # Test with HDF5 support disabled.
+  (cargo_nix.rootCrate.build.override {
+    features = [ "model-tests" ];
+    runTests = true;
+  })
+
+  # Test with HDF5 support.
+  (cargo_nix.rootCrate.build.override {
+    features = [ "load-hdf5" "model-tests" ];
+    runTests = true;
+  })
+]


### PR DESCRIPTION
This feature is enabled by default, so this change does not result in
API changes. However, the `load-hdf5` feature can be disabled to
compile sticker-transformers without relying on libhdf5.