### PR TITLE
Add Encoder trait, implemented by BertEncoder and AlbertEncoder

### DIFF
--- a/src/models/encoder.rs
+++ b/src/models/encoder.rs
@@ -1,0 +1,22 @@
+use tch::Tensor;
+
+use crate::models::bert::BertLayerOutput;
+
+/// Encoder networks.
+pub trait Encoder {
+    /// Apply the encoder.
+    ///
+    /// Returns the output and attention per layer. The (optional)
+    /// attention mask of shape `[batch_size, time_steps]` indicates
+    /// which tokens should be included (`true`) and excluded (`false`) from
+    /// attention. This can be used to mask inactive timesteps.
+    fn encode(
+        &self,
+        input: &Tensor,
+        attention_mask: Option<&Tensor>,
+        train: bool,
+    ) -> Vec<BertLayerOutput>;
+
+    /// Get the number of layers that is returned by the encoder.
+    fn n_layers(&self) -> i64;
+}

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -5,6 +5,9 @@ pub mod albert;
 pub mod bert;
 pub use bert::{BertConfig, BertEmbeddings, BertEncoder};
 
+mod encoder;
+pub use encoder::Encoder;
+
 pub mod roberta;
 pub use roberta::RobertaEmbeddings;
 

--- a/src/models/roberta/mod.rs
+++ b/src/models/roberta/mod.rs
@@ -112,6 +112,7 @@ mod tests {
     use crate::hdf5_model::LoadFromHDF5;
     use crate::models::bert::{BertConfig, BertEncoder};
     use crate::models::roberta::RobertaEmbeddings;
+    use crate::models::Encoder;
 
     const XLM_ROBERTA_BASE: &str = env!("XLM_ROBERTA_BASE");
 
@@ -199,7 +200,7 @@ mod tests {
 
         let embeddings = embeddings.forward_t(&pieces, false);
 
-        let all_hidden_states = encoder.forward_t(&embeddings, None, false);
+        let all_hidden_states = encoder.encode(&embeddings, None, false);
 
         let summed_last_hidden =
             all_hidden_states

--- a/src/scalar_weighting.rs
+++ b/src/scalar_weighting.rs
@@ -343,11 +343,11 @@ mod tests {
         );
 
         let layer1 = BertLayerOutput {
-            attention: Tensor::zeros(&[1, 3, 2], (Kind::Float, Device::Cpu)),
+            attention: Some(Tensor::zeros(&[1, 3, 2], (Kind::Float, Device::Cpu))),
             output: Tensor::zeros(&[1, 3, 8], (Kind::Float, Device::Cpu)),
         };
         let layer2 = BertLayerOutput {
-            attention: Tensor::zeros(&[1, 3, 2], (Kind::Float, Device::Cpu)),
+            attention: Some(Tensor::zeros(&[1, 3, 2], (Kind::Float, Device::Cpu))),
             output: Tensor::zeros(&[1, 3, 8], (Kind::Float, Device::Cpu)),
         };
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -3,7 +3,7 @@ use tch::Tensor;
 /// Trait to get the attention of a layer.
 pub trait LayerAttention {
     /// Get the attention of a layer.
-    fn layer_attention(&self) -> &Tensor;
+    fn layer_attention(&self) -> Option<&Tensor>;
 }
 
 /// Trait to get the output of a layer.


### PR DESCRIPTION
- This trait allows us to get the number of layers, besides encoding
  an input.
- Let AlbertEncoder return the projected word embeddings.
- Feature gate HDF5 loading for ALBERT to fix tests.